### PR TITLE
AH-1814/asyncapi-we-need-a-more-flexible-and-robust-way-to-manage-pids

### DIFF
--- a/lib/asyncapi/broker/dummy.ex
+++ b/lib/asyncapi/broker/dummy.ex
@@ -1,4 +1,6 @@
+
 defmodule Asyncapi.Broker.Dummy do
+  @behaviour Asyncapi.Broker
   def connect(asyncapi) do
     # dbg(asyncapi.subscriptions)
     Enum.each(asyncapi.subscriptions, &DummyBroker.subscribe(&1))

--- a/lib/asyncapi/broker/mqtt.ex
+++ b/lib/asyncapi/broker/mqtt.ex
@@ -1,4 +1,6 @@
 defmodule Asyncapi.Broker.MQTT do
+  @behaviour Asyncapi.Broker
+
   require Logger
 
   def connect(asyncapi) do

--- a/test/asyncapi/test_helper_test.exs
+++ b/test/asyncapi/test_helper_test.exs
@@ -62,16 +62,15 @@ defmodule Asyncapi.TestHelperTest do
   @moduletag capture_log: true
 
   test "runs when everything is ok", context do
-    {:ok, pid} = start_supervised(TestHelper.Internal)
+    {:ok, time_server_pid} = start_supervised(TestHelper.Internal)
 
     {:ok, additional} =
       TestHelper.start_service(
         Baking,
         Baking.TestUserSchema,
         Asyncapi.Broker.Dummy,
-        service_opts: [
-          time_server: pid
-        ]
+        service_opts: [time_server: time_server_pid],
+        internal_pids: %{time_server: time_server_pid}
       )
 
     full_context = Enum.into(additional, context)
@@ -90,16 +89,15 @@ defmodule Asyncapi.TestHelperTest do
   end
 
   test "fails on error", context do
-    {:ok, pid} = start_supervised(TestHelper.Internal)
+    {:ok, time_server_pid} = start_supervised(TestHelper.Internal)
 
     {:ok, additional} =
       TestHelper.start_service(
         Baking,
         Baking.TestUserSchema,
         Asyncapi.Broker.Dummy,
-        service_opts: [
-          time_server: pid
-        ]
+        service_opts: [time_server: time_server_pid],
+        internal_pids: %{time_server: time_server_pid}
       )
 
     full_context = Enum.into(additional, context)


### PR DESCRIPTION
hab das jetzt vorerst doch mit einer Funktion gemacht.
Und die Funktion wuerde ich in init() umbenennen.